### PR TITLE
[novel] harden Cloudflare handler: header sanitization, CSP stripping, retry-once

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -257,6 +257,7 @@ dependencies {
     implementation(androidx.recyclerview)
     implementation(androidx.viewpager)
     implementation(androidx.profileinstaller)
+    implementation(androidx.webkit)
     implementation(aniyomilibs.mediasession)
 
     implementation(androidx.bundles.lifecycle)

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -34,6 +34,8 @@ dependencies {
     implementation(libs.unifile)
     implementation(libs.libarchive)
 
+    implementation(androidx.webkit)
+
     api(kotlinx.coroutines.core)
     api(kotlinx.serialization.json)
     api(kotlinx.serialization.json.okio)

--- a/core/common/src/main/java/eu/kanade/tachiyomi/network/NetworkHelper.kt
+++ b/core/common/src/main/java/eu/kanade/tachiyomi/network/NetworkHelper.kt
@@ -67,7 +67,12 @@ class NetworkHelper(
 
     val client = clientBuilder
         .addInterceptor(
-            CloudflareInterceptor(context, cookieJar, ::defaultUserAgentProvider),
+            CloudflareInterceptor(
+                context = context,
+                cookieManager = cookieJar,
+                defaultUserAgentProvider = ::defaultUserAgentProvider,
+                nonCloudflareClientProvider = { nonCloudflareClient },
+            ),
         )
         .build()
 

--- a/core/common/src/main/java/eu/kanade/tachiyomi/network/interceptor/CloudflareChallengeResolver.kt
+++ b/core/common/src/main/java/eu/kanade/tachiyomi/network/interceptor/CloudflareChallengeResolver.kt
@@ -12,10 +12,15 @@ import eu.kanade.tachiyomi.network.AndroidCookieJar
 import eu.kanade.tachiyomi.util.system.toast
 import okhttp3.Cookie
 import okhttp3.Headers
+import okhttp3.OkHttpClient
 import okhttp3.Request
 import tachiyomi.i18n.MR
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.util.Locale
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
 
 interface CloudflareChallengeResolver {
     fun resolve(originalRequest: Request, oldCookie: Cookie?)
@@ -28,6 +33,7 @@ internal class WebViewCloudflareChallengeResolver(
     private val createWebView: (Request) -> WebView,
     private val parseHeaders: (Headers) -> Map<String, String>,
     private val isWebViewOutdated: (WebView) -> Boolean,
+    private val nonCloudflareClientProvider: () -> OkHttpClient? = { null },
 ) : CloudflareChallengeResolver {
 
     @SuppressLint("SetJavaScriptEnabled")
@@ -37,9 +43,11 @@ internal class WebViewCloudflareChallengeResolver(
         var webview: WebView? = null
         var challengeFound = false
         var cloudflareBypassed = false
+        var hasInteractiveWidget = false
         var isWebViewOutdatedNow = false
 
         val origRequestUrl = originalRequest.url.toString()
+        val targetHost = originalRequest.url.host
         val headers = parseHeaders(originalRequest.headers)
 
         mainExecutor.execute {
@@ -47,6 +55,14 @@ internal class WebViewCloudflareChallengeResolver(
             webview = createdWebView
 
             createdWebView.webViewClient = object : WebViewClient() {
+                override fun shouldInterceptRequest(
+                    view: WebView,
+                    request: WebResourceRequest,
+                ): WebResourceResponse? {
+                    val client = nonCloudflareClientProvider() ?: return null
+                    return interceptMainFrameForCspStripping(client, request, targetHost)
+                }
+
                 override fun onPageFinished(view: WebView, url: String) {
                     fun isCloudFlareBypassed(): Boolean {
                         return cookieManager.get(originalRequest.url)
@@ -94,6 +110,10 @@ internal class WebViewCloudflareChallengeResolver(
 
         latch.awaitFor30Seconds()
 
+        if (!cloudflareBypassed) {
+            hasInteractiveWidget = detectInteractiveWidgetSync(webview)
+        }
+
         mainExecutor.execute {
             if (!cloudflareBypassed) {
                 isWebViewOutdatedNow = webview?.let(isWebViewOutdated) == true
@@ -108,15 +128,108 @@ internal class WebViewCloudflareChallengeResolver(
         if (!cloudflareBypassed) {
             if (isWebViewOutdatedNow) {
                 context.toast(MR.strings.information_webview_outdated, Toast.LENGTH_LONG)
+            } else if (hasInteractiveWidget) {
+                context.toast(MR.strings.information_cloudflare_interactive_challenge, Toast.LENGTH_LONG)
+                throw CloudflareInteractiveChallengeException()
             }
 
             throw CloudflareBypassException()
         }
     }
+
+    private fun detectInteractiveWidgetSync(webview: WebView?): Boolean {
+        if (webview == null) return false
+        val checkLatch = CountDownLatch(1)
+        var detected = false
+        mainExecutor.execute {
+            try {
+                webview.evaluateJavascript(INTERACTIVE_WIDGET_PROBE) { result ->
+                    detected = result == "true"
+                    checkLatch.countDown()
+                }
+            } catch (_: Throwable) {
+                checkLatch.countDown()
+            }
+        }
+        checkLatch.await(2, TimeUnit.SECONDS)
+        return detected
+    }
 }
+
+/**
+ * Strip `Content-Security-Policy` (and `*-Report-Only`) from main-frame responses on the
+ * Cloudflare-protected host so that the challenge JS isn't blocked by Trusted Types or
+ * nonce-only inline-script policies set by the page.
+ *
+ * Returns null to let WebView handle the request normally for any non-matching case.
+ */
+private fun interceptMainFrameForCspStripping(
+    client: OkHttpClient,
+    request: WebResourceRequest,
+    targetHost: String,
+): WebResourceResponse? {
+    if (!request.isForMainFrame) return null
+    if (!request.method.equals("GET", ignoreCase = true)) return null
+    val requestHost = request.url.host ?: return null
+    if (!requestHost.equals(targetHost, ignoreCase = true)) return null
+
+    return try {
+        val okHttpRequest = Request.Builder()
+            .url(request.url.toString())
+            .apply {
+                request.requestHeaders?.forEach { (name, value) ->
+                    if (value != null) addHeader(name, value)
+                }
+            }
+            .get()
+            .build()
+
+        client.newCall(okHttpRequest).execute().use { response ->
+            val mediaType = response.body.contentType()
+            val mimeType = mediaType?.let { "${it.type}/${it.subtype}" } ?: "text/html"
+            val charset = mediaType?.charset()?.name() ?: "UTF-8"
+            val bodyBytes = response.body.bytes()
+            val sanitizedHeaders = response.headers.toMultimap()
+                .filterKeys { name -> name.lowercase(Locale.ROOT) !in CSP_HEADER_NAMES }
+                .mapValues { it.value.joinToString(", ") }
+            val reason = response.message.ifBlank { "OK" }
+            WebResourceResponse(
+                mimeType,
+                charset,
+                response.code,
+                reason,
+                sanitizedHeaders,
+                ByteArrayInputStream(bodyBytes),
+            )
+        }
+    } catch (_: IOException) {
+        null
+    } catch (_: Throwable) {
+        null
+    }
+}
+
+private val CSP_HEADER_NAMES = setOf(
+    "content-security-policy",
+    "content-security-policy-report-only",
+)
+
+private val INTERACTIVE_WIDGET_PROBE = """
+    (function() {
+        try {
+            var hasTurnstile = document.querySelector('.cf-turnstile, [data-sitekey], iframe[src*="challenges.cloudflare.com"]') != null;
+            var hasManaged = document.getElementById('challenge-stage') != null ||
+                document.getElementById('cf-please-wait') != null;
+            return hasTurnstile || hasManaged;
+        } catch (_) {
+            return false;
+        }
+    })();
+""".trimIndent()
 
 private fun CountDownLatch.awaitFor30Seconds() {
-    await(30, java.util.concurrent.TimeUnit.SECONDS)
+    await(30, TimeUnit.SECONDS)
 }
 
-internal class CloudflareBypassException : Exception()
+internal open class CloudflareBypassException : Exception()
+internal class CloudflareInteractiveChallengeException : CloudflareBypassException()

--- a/core/common/src/main/java/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
+++ b/core/common/src/main/java/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
@@ -5,9 +5,9 @@ import androidx.core.content.ContextCompat
 import eu.kanade.tachiyomi.network.AndroidCookieJar
 import eu.kanade.tachiyomi.util.system.isOutdated
 import okhttp3.Interceptor
+import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
-import org.jsoup.Jsoup
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.i18n.MR
 import java.io.IOException
@@ -17,6 +17,7 @@ class CloudflareInterceptor(
     private val context: Context,
     private val cookieManager: AndroidCookieJar,
     defaultUserAgentProvider: () -> String,
+    nonCloudflareClientProvider: () -> OkHttpClient? = { null },
     private val challengeResolver: CloudflareChallengeResolver? = null,
 ) : WebViewInterceptor(context, defaultUserAgentProvider) {
 
@@ -28,6 +29,7 @@ class CloudflareInterceptor(
         createWebView = this::createWebView,
         parseHeaders = this::parseHeaders,
         isWebViewOutdated = { it.isOutdated() },
+        nonCloudflareClientProvider = nonCloudflareClientProvider,
     )
 
     override fun shouldIntercept(response: Response): Boolean {
@@ -37,30 +39,49 @@ class CloudflareInterceptor(
         if (response.header("cf-mitigated")?.equals("challenge", ignoreCase = true) == true) {
             return true
         }
-        val document = Jsoup.parse(
-            response.peekBody(Long.MAX_VALUE).string(),
-            response.request.url.toString(),
-        )
-        return document.getElementById("challenge-error-title") != null ||
-            document.getElementById("challenge-error-text") != null
+        // Limit body inspection to a small prefix; challenge markup is at the top of the
+        // document and full body parsing wastes memory on large pages.
+        val bodyPeek = response.peekBody(CHALLENGE_PEEK_BYTES).string()
+        if (!CHALLENGE_HTML_MARKERS.any { it in bodyPeek }) {
+            return false
+        }
+        return true
     }
 
     override fun intercept(chain: Interceptor.Chain, request: Request, response: Response): Response {
+        val host = request.url.host
         try {
             response.close()
-            val hostLock = challengeLockByHost.getOrPut(request.url.host) { Any() }
-            synchronized(hostLock) {
-                cookieManager.remove(request.url, COOKIE_NAMES, 0)
-                val oldCookie = cookieManager.get(request.url)
-                    .firstOrNull { it.name == "cf_clearance" }
+            val hostLock = challengeLockByHost.getOrPut(host) { Any() }
+            try {
+                synchronized(hostLock) {
+                    cookieManager.remove(request.url, COOKIE_NAMES, 0)
+                    val oldCookie = cookieManager.get(request.url)
+                        .firstOrNull { it.name == "cf_clearance" }
 
-                webViewChallengeResolver.resolve(request, oldCookie)
-                return chain.proceed(request)
+                    webViewChallengeResolver.resolve(request, oldCookie)
+
+                    val firstAttempt = chain.proceed(request)
+                    if (!shouldIntercept(firstAttempt)) {
+                        return firstAttempt
+                    }
+                    // The cookie set on CookieManager may not have propagated to OkHttp's
+                    // CookieJar yet for the in-flight connection; close and retry once.
+                    firstAttempt.close()
+                    return chain.proceed(request)
+                }
+            } finally {
+                challengeLockByHost.remove(host, hostLock)
             }
         }
         // Because OkHttp's enqueue only handles IOExceptions, wrap the exception so that
         // we don't crash the entire app
-        catch (e: CloudflareBypassException) {
+        catch (e: CloudflareInteractiveChallengeException) {
+            throw IOException(
+                context.stringResource(MR.strings.information_cloudflare_interactive_challenge),
+                e,
+            )
+        } catch (e: CloudflareBypassException) {
             throw IOException(context.stringResource(MR.strings.information_cloudflare_bypass_failure), e)
         } catch (e: Exception) {
             throw IOException(e)
@@ -71,3 +92,13 @@ class CloudflareInterceptor(
 internal val ERROR_CODES = listOf(403, 503)
 private val SERVER_CHECK = arrayOf("cloudflare-nginx", "cloudflare")
 private val COOKIE_NAMES = listOf("cf_clearance")
+
+// Just enough to capture the challenge headers/error markers; the page body is larger
+// but the challenge identifiers always appear near the top.
+private const val CHALLENGE_PEEK_BYTES = 8L * 1024L
+private val CHALLENGE_HTML_MARKERS = arrayOf(
+    "challenge-error-title",
+    "challenge-error-text",
+    "cf-mitigated",
+    "cf-error-details",
+)

--- a/core/common/src/main/java/eu/kanade/tachiyomi/network/interceptor/WebViewInterceptor.kt
+++ b/core/common/src/main/java/eu/kanade/tachiyomi/network/interceptor/WebViewInterceptor.kt
@@ -7,6 +7,7 @@ import android.webkit.WebView
 import android.widget.Toast
 import eu.kanade.tachiyomi.util.system.DeviceUtil
 import eu.kanade.tachiyomi.util.system.WebViewUtil
+import eu.kanade.tachiyomi.util.system.sanitizeCloudflareRequestHeaders
 import eu.kanade.tachiyomi.util.system.setDefaultSettings
 import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.DelicateCoroutinesApi
@@ -69,13 +70,20 @@ abstract class WebViewInterceptor(
     }
 
     fun parseHeaders(headers: Headers): Map<String, String> {
-        return headers
+        val safeHeaders = headers
             // Keeping unsafe header makes webview throw [net::ERR_INVALID_ARGUMENT]
             .filter { (name, value) ->
                 isRequestHeaderSafe(name, value)
             }
             .groupBy(keySelector = { (name, _) -> name }) { (_, value) -> value }
             .mapValues { it.value.getOrNull(0).orEmpty() }
+        // Strip headers that fingerprint Android WebView for anti-bot services like
+        // Cloudflare (sec-ch-ua client hints + the X-Requested-With package name).
+        return sanitizeCloudflareRequestHeaders(
+            requestHeaders = safeHeaders,
+            contextPackageName = context.packageName,
+            spoofedPackageName = WebViewUtil.spoofedPackageName(context),
+        )
     }
 
     fun CountDownLatch.awaitFor30Seconds() {

--- a/core/common/src/main/java/eu/kanade/tachiyomi/util/system/WebViewUtil.kt
+++ b/core/common/src/main/java/eu/kanade/tachiyomi/util/system/WebViewUtil.kt
@@ -6,6 +6,8 @@ import android.content.pm.PackageManager
 import android.webkit.CookieManager
 import android.webkit.WebSettings
 import android.webkit.WebView
+import androidx.webkit.WebSettingsCompat
+import androidx.webkit.WebViewFeature
 import kotlinx.coroutines.suspendCancellableCoroutine
 import logcat.LogPriority
 import tachiyomi.core.common.util.system.logcat
@@ -89,6 +91,12 @@ fun WebView.setDefaultSettings() {
         setSupportZoom(true)
         builtInZoomControls = true
         displayZoomControls = false
+
+        // Don't expose the host package in X-Requested-With on subresource requests;
+        // anti-bot services (notably Cloudflare) use it as an Android WebView fingerprint.
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.REQUESTED_WITH_HEADER_ALLOW_LIST)) {
+            WebSettingsCompat.setRequestedWithHeaderOriginAllowList(this, emptySet())
+        }
     }
 
     CookieManager.getInstance().acceptThirdPartyCookies(this)

--- a/core/common/src/test/java/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptorTest.kt
+++ b/core/common/src/test/java/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptorTest.kt
@@ -6,7 +6,6 @@ import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
-import okhttp3.Cookie
 import okhttp3.Interceptor
 import okhttp3.Protocol
 import okhttp3.Request
@@ -14,6 +13,7 @@ import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import java.io.IOException
 
 class CloudflareInterceptorTest {
 
@@ -105,11 +105,100 @@ class CloudflareInterceptorTest {
         verify(exactly = 1) { chain.proceed(request) }
     }
 
+    @Test
+    fun `intercept retries once when first proceed still hits cloudflare challenge`() {
+        val request = Request.Builder()
+            .url("https://novel.tl/page/1")
+            .build()
+
+        val initialResponse = response(
+            request = request,
+            code = 403,
+            message = "Forbidden",
+            server = "cloudflare",
+        )
+        val challengeStillUp = response(
+            request = request,
+            code = 403,
+            message = "Forbidden",
+            server = "cloudflare",
+            cfMitigated = true,
+        )
+        val finalResponse = response(
+            request = request,
+            code = 200,
+            message = "OK",
+            server = null,
+        )
+
+        val cookieJar = mockk<AndroidCookieJar>()
+        every { cookieJar.get(request.url) } returns emptyList()
+        every { cookieJar.remove(request.url, listOf("cf_clearance"), 0) } returns 0
+
+        val challengeResolver = mockk<CloudflareChallengeResolver>()
+        justRun { challengeResolver.resolve(request, null) }
+
+        val chain = mockk<Interceptor.Chain>()
+        every { chain.proceed(request) } returnsMany listOf(challengeStillUp, finalResponse)
+
+        val interceptor = CloudflareInterceptor(
+            context = mockk<Context>(relaxed = true),
+            cookieManager = cookieJar,
+            defaultUserAgentProvider = { "test-agent" },
+            challengeResolver = challengeResolver,
+        )
+
+        val result = interceptor.intercept(chain, request, initialResponse)
+
+        assertEquals(200, result.code)
+        verify(exactly = 1) { challengeResolver.resolve(request, null) }
+        verify(exactly = 2) { chain.proceed(request) }
+    }
+
+    @Test
+    fun `intercept surfaces interactive challenge as IOException`() {
+        val request = Request.Builder()
+            .url("https://novel.tl/page/1")
+            .build()
+
+        val initialResponse = response(
+            request = request,
+            code = 403,
+            message = "Forbidden",
+            server = "cloudflare",
+        )
+
+        val cookieJar = mockk<AndroidCookieJar>()
+        every { cookieJar.get(request.url) } returns emptyList()
+        every { cookieJar.remove(request.url, listOf("cf_clearance"), 0) } returns 0
+
+        val challengeResolver = mockk<CloudflareChallengeResolver>()
+        every { challengeResolver.resolve(request, null) } throws CloudflareInteractiveChallengeException()
+
+        val chain = mockk<Interceptor.Chain>()
+
+        val interceptor = CloudflareInterceptor(
+            context = mockk<Context>(relaxed = true),
+            cookieManager = cookieJar,
+            defaultUserAgentProvider = { "test-agent" },
+            challengeResolver = challengeResolver,
+        )
+
+        try {
+            interceptor.intercept(chain, request, initialResponse)
+            assert(false) { "expected IOException" }
+        } catch (e: IOException) {
+            assert(e.cause is CloudflareInteractiveChallengeException)
+        }
+        verify(exactly = 0) { chain.proceed(request) }
+    }
+
     private fun response(
         request: Request,
         code: Int,
         message: String,
         server: String?,
+        cfMitigated: Boolean = false,
     ): Response {
         return Response.Builder()
             .request(request)
@@ -119,6 +208,9 @@ class CloudflareInterceptorTest {
             .apply {
                 if (server != null) {
                     addHeader("Server", server)
+                }
+                if (cfMitigated) {
+                    addHeader("cf-mitigated", "challenge")
                 }
             }
             .body("".toResponseBody())

--- a/gradle/androidx.versions.toml
+++ b/gradle/androidx.versions.toml
@@ -16,6 +16,7 @@ splashscreen = "androidx.core:core-splashscreen:1.0.1"
 recyclerview = "androidx.recyclerview:recyclerview:1.4.0"
 viewpager = "androidx.viewpager:viewpager:1.1.0"
 profileinstaller = "androidx.profileinstaller:profileinstaller:1.4.1"
+webkit = "androidx.webkit:webkit:1.13.0"
 
 lifecycle-common = { module = "androidx.lifecycle:lifecycle-common", version.ref = "lifecycle_version" }
 lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "lifecycle_version" }

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -1001,6 +1001,7 @@
     <string name="information_empty_category_dialog">You don\'t have any categories yet.</string>
     <string name="information_cloudflare_bypass_failure">Failed to bypass Cloudflare</string>
     <string name="information_cloudflare_help">Tap here for help with Cloudflare</string>
+    <string name="information_cloudflare_interactive_challenge">Cloudflare needs you: open the source\'s WebView and complete the challenge</string>
     <string name="information_required_plain">*required</string>
     <!-- Do not translate "WebView" -->
     <string name="information_webview_required">WebView is required for the app to function</string>


### PR DESCRIPTION
## Summary

Targets the Cloudflare Turnstile/challenge failures observed against `https://www.foxaholic.com` (logs in chat). The challenge WebView was reaching Cloudflare with telltale Android fingerprints and was then having its own challenge scripts blocked by the page's Trusted Types CSP, so `cf_clearance` was never issued. This PR closes those gaps and makes the resolver more robust.

### What was actually broken

- `sec-ch-ua`, `sec-ch-ua-full-version-list` and `X-Requested-With: com.tadami.aurora.localdev` were forwarded to Cloudflare from the WebView interceptor — `sanitizeCloudflareRequestHeaders` existed but was never wired up.
- The challenge document inherited the parent site's `Content-Security-Policy: ... require-trusted-types-for 'script'`, which is exactly the source of the `TrustedHTML/TrustedScript/TrustedScriptURL ... action has been blocked` lines in the logs. Without those scripts the Turnstile pipeline never finishes.
- `androidx.webkit` was not on the classpath, so we couldn't disable WebView's `X-Requested-With` exposure on subresource requests (API ≥ 33).

### P0 — root-cause fixes

- Wire `sanitizeCloudflareRequestHeaders` into `WebViewInterceptor.parseHeaders` so the `sec-ch-ua*` client hints and any leaking package name in `X-Requested-With` are stripped before headers leave the app.
- Strip `Content-Security-Policy[-Report-Only]` from main-frame challenge responses inside `CloudflareChallengeResolver` via a new `shouldInterceptRequest` path. The intercepted main-frame request goes through a non-Cloudflare `OkHttpClient` (provided by `NetworkHelper.nonCloudflareClient`), the response is rewritten without CSP headers, and Trusted Types no longer block Cloudflare's own inline scripts.
- Add `androidx.webkit:webkit:1.13.0` and call `WebSettingsCompat.setRequestedWithHeaderOriginAllowList(emptySet())` in `WebViewUtil.setDefaultSettings`, so the host package is not announced as `X-Requested-With` on any subresource on API ≥ 33 (no-op below).

### P1 — robustness/UX

- Retry the original request once if the first `chain.proceed` after challenge resolution still trips `shouldIntercept` (covers the `cf_clearance` cookie ↔ existing connection-pool race).
- New `CloudflareInteractiveChallengeException` (extends `CloudflareBypassException`); the resolver throws it when a challenge times out *and* a `.cf-turnstile` / `[data-sitekey]` / `challenges.cloudflare.com` iframe / managed challenge stage is detected. `CloudflareInterceptor` wraps it as an `IOException` with a dedicated string telling the user to open WebView for the source.
- `shouldIntercept` now does a `peekBody(8 KiB)` substring check (`challenge-error-title`, `challenge-error-text`, `cf-mitigated`, `cf-error-details`) instead of parsing the full body with Jsoup at `Long.MAX_VALUE`.
- Per-host challenge locks (`challengeLockByHost`) are released in a `finally` block so we don't leak a `ConcurrentHashMap` entry per host that ever hits Cloudflare.

### What this does NOT do (deferred)

P2/P3 from the analysis are intentionally out of scope: console-noise filter for `Permissions-Policy`/`postMessage` warnings, `mixedContentMode`/`safeBrowsing` tweaks, UA-regex rewrites, and metrics. They're behavioural changes that should ride a separate PR after we confirm this one resolves the real failures.

## Validation

- `./gradlew :core:common:compileDebugKotlin` — green
- `./gradlew :core:common:testDebugUnitTest` — all 9 tests pass, including two new ones:
  - `intercept retries once when first proceed still hits cloudflare challenge`
  - `intercept surfaces interactive challenge as IOException`
- `./gradlew :app:compileDebugKotlin` — green
- `./gradlew :core:common:spotlessCheck` — green. Top-level `:app:spotlessCheck` fails on pre-existing `NovelJsSource{,Test}.kt` violations that are present on `ranobe-novel` itself (verified by stashing this PR and re-running) — unrelated.

- [x] I ran the required automated checks for this change.
- [x] I self-reviewed the diff and validated critical user flows.

Requested by: @andarcanum