### PR TITLE
[aurora-library] toggle to switch categories with horizontal swipe

### DIFF
--- a/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
@@ -51,6 +51,11 @@ class UiPreferences(
         false,
     )
 
+    fun auroraLibrarySwipeSwitchesCategories() = preferenceStore.getBoolean(
+        "aurora_library_swipe_switches_categories",
+        false,
+    )
+
     fun libraryUpdatePacingTimeoutSeconds() = preferenceStore.getInt(
         "library_update_pacing_timeout_seconds",
         0,

--- a/app/src/main/java/eu/kanade/presentation/components/TabbedScreenAurora.kt
+++ b/app/src/main/java/eu/kanade/presentation/components/TabbedScreenAurora.kt
@@ -53,6 +53,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -87,6 +88,7 @@ import kotlinx.coroutines.launch
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.LocalAppHaptics
+import kotlin.math.abs
 import kotlin.math.roundToInt
 
 data class TabState(
@@ -121,6 +123,7 @@ fun TabbedScreenAurora(
     extraSearchToActionsGap: Dp = 0.dp,
     extraActionGapAfterTitle: String? = null,
     extraHeaderContent: @Composable () -> Unit = {},
+    onPagerSwipeOverride: ((forward: Boolean) -> Boolean)? = null,
 ) {
     val auroraAdaptiveSpec = rememberAuroraAdaptiveSpec()
     val contentMaxWidthDp = auroraAdaptiveSpec.updatesMaxWidthDp ?: auroraAdaptiveSpec.entryMaxWidthDp
@@ -324,26 +327,76 @@ fun TabbedScreenAurora(
                     }
                 }
             } else {
-                HorizontalPager(
-                    modifier = Modifier.fillMaxSize(),
-                    state = state,
-                    verticalAlignment = Alignment.Top,
-                ) { page ->
-                    val tabState = TabState(
-                        tabs = tabs,
-                        selectedIndex = state.currentPage,
-                        onTabSelected = onTabSelected,
-                    )
-                    CompositionLocalProvider(LocalTabState provides tabState) {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .auroraCenteredMaxWidth(contentMaxWidthDp),
-                        ) {
-                            tabs[page].content(
-                                PaddingValues(bottom = 16.dp),
-                                snackbarHostState,
+                val pagerOverrideActive = onPagerSwipeOverride != null
+                val latestPagerSwipeOverride = rememberUpdatedState(onPagerSwipeOverride)
+                val pagerContainerModifier = if (pagerOverrideActive) {
+                    Modifier
+                        .fillMaxSize()
+                        .pointerInput(switchThresholdPx, maxBouncePx) {
+                            var totalDragPx = 0f
+                            detectHorizontalDragGestures(
+                                onDragStart = {
+                                    totalDragPx = 0f
+                                    edgeBounceTargetPx = 0f
+                                },
+                                onHorizontalDrag = { _, dragAmount ->
+                                    totalDragPx += dragAmount
+                                },
+                                onDragCancel = {
+                                    totalDragPx = 0f
+                                    edgeBounceTargetPx = 0f
+                                },
+                                onDragEnd = {
+                                    val dragMagnitude = abs(totalDragPx)
+                                    if (dragMagnitude >= switchThresholdPx) {
+                                        // Swipe-left (negative) means "forward" (next item).
+                                        val forward = totalDragPx < 0f
+                                        val consumed = latestPagerSwipeOverride.value
+                                            ?.invoke(forward) == true
+                                        if (!consumed) {
+                                            val direction = if (totalDragPx > 0f) 1f else -1f
+                                            scope.launch {
+                                                edgeBounceTargetPx = direction * maxBouncePx
+                                                delay(90)
+                                                edgeBounceTargetPx = 0f
+                                            }
+                                        } else {
+                                            edgeBounceTargetPx = 0f
+                                        }
+                                    } else {
+                                        edgeBounceTargetPx = 0f
+                                    }
+                                    totalDragPx = 0f
+                                },
                             )
+                        }
+                        .offset { IntOffset(edgeBounceOffsetPx.roundToInt(), 0) }
+                } else {
+                    Modifier.fillMaxSize()
+                }
+                Box(modifier = pagerContainerModifier) {
+                    HorizontalPager(
+                        modifier = Modifier.fillMaxSize(),
+                        state = state,
+                        verticalAlignment = Alignment.Top,
+                        userScrollEnabled = !pagerOverrideActive,
+                    ) { page ->
+                        val tabState = TabState(
+                            tabs = tabs,
+                            selectedIndex = state.currentPage,
+                            onTabSelected = onTabSelected,
+                        )
+                        CompositionLocalProvider(LocalTabState provides tabState) {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .auroraCenteredMaxWidth(contentMaxWidthDp),
+                            ) {
+                                tabs[page].content(
+                                    PaddingValues(bottom = 16.dp),
+                                    snackbarHostState,
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
@@ -507,6 +507,13 @@ object SettingsLibraryScreen : SearchableSettings {
                     title = stringResource(AYMR.strings.pref_aurora_library_immersive_mode),
                     subtitle = stringResource(AYMR.strings.pref_aurora_library_immersive_mode_summary),
                 ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = uiPreferences.auroraLibrarySwipeSwitchesCategories(),
+                    title = stringResource(AYMR.strings.pref_aurora_library_swipe_switches_categories),
+                    subtitle = stringResource(
+                        AYMR.strings.pref_aurora_library_swipe_switches_categories_summary,
+                    ),
+                ),
             ),
         )
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/anime/AnimeLibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/anime/AnimeLibraryTab.kt
@@ -229,6 +229,9 @@ data object AnimeLibraryTab : Tab {
         val showMangaSection by uiPreferences.showMangaSection().collectAsState()
         val showNovelSection by uiPreferences.showNovelSection().collectAsState()
         val immersiveModeEnabled by uiPreferences.auroraLibraryImmersiveMode().collectAsState()
+        val swipeSwitchesCategories by uiPreferences
+            .auroraLibrarySwipeSwitchesCategories()
+            .collectAsState()
         val bottomNavVisibilityController = LocalBottomNavVisibilityController.current
         val useSeparateDisplayModePerMedia by settingsScreenModel
             .libraryPreferences
@@ -778,6 +781,24 @@ data object AnimeLibraryTab : Tab {
                 null -> Unit
             }
         }
+        val onAuroraCategorySwipe: ((Boolean) -> Boolean)? = if (
+            swipeSwitchesCategories &&
+            auroraCurrentSection != null &&
+            auroraCategories.size > 1
+        ) {
+            { forward ->
+                val current = auroraCategoryIndex
+                val target = if (forward) current + 1 else current - 1
+                if (target in auroraCategories.indices && target != current) {
+                    onAuroraCategorySelected(target)
+                    true
+                } else {
+                    false
+                }
+            }
+        } else {
+            null
+        }
         val onAuroraRefreshCurrent: () -> Unit = {
             when (auroraCurrentSection) {
                 Section.Anime -> onClickRefresh(state.categories.getOrNull(animeCategoryIndex))
@@ -1054,6 +1075,7 @@ data object AnimeLibraryTab : Tab {
                                     },
                                 )
                             },
+                            onPagerSwipeOverride = onAuroraCategorySwipe,
                         )
                     } else {
                         AnimeLibraryContent(

--- a/app/src/test/java/eu/kanade/domain/ui/UiPreferencesImmersiveModeTest.kt
+++ b/app/src/test/java/eu/kanade/domain/ui/UiPreferencesImmersiveModeTest.kt
@@ -12,4 +12,11 @@ class UiPreferencesImmersiveModeTest {
 
         prefs.auroraLibraryImmersiveMode().get() shouldBe false
     }
+
+    @Test
+    fun `aurora library swipe-switches-categories is disabled by default`() {
+        val prefs = UiPreferences(InMemoryPreferenceStore())
+
+        prefs.auroraLibrarySwipeSwitchesCategories().get() shouldBe false
+    }
 }

--- a/i18n-aniyomi/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/base/strings.xml
@@ -56,6 +56,8 @@
     <string name="pref_library_update_show_tab_badge">Show unseen/unread count on Updates icon</string>
     <string name="pref_aurora_library_immersive_mode">Immersive mode</string>
     <string name="pref_aurora_library_immersive_mode_summary">Hide the top chrome and bottom navigation while scrolling, but keep categories visible.</string>
+    <string name="pref_aurora_library_swipe_switches_categories">Swipe switches categories</string>
+    <string name="pref_aurora_library_swipe_switches_categories_summary">Use horizontal swipes on the library to switch between categories instead of sections (anime/manga/novels).</string>
     <string name="pref_category_delete_chapters">Delete chapters/episodes</string>
     <string name="pref_remove_after_marked_as_read">After manually marked as read/watched</string>
     <string name="pref_remove_after_read">After reading/watching automatically delete</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/ru/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/ru/strings.xml
@@ -50,6 +50,8 @@
     <string name="pref_library_update_show_tab_badge">Показывать количество непросмотренных/непрочитанных на значке обновлений</string>
     <string name="pref_aurora_library_immersive_mode">Режим погружения</string>
     <string name="pref_aurora_library_immersive_mode_summary">Скрывать верхнюю панель и нижнюю навигацию при прокрутке, но оставлять категории видимыми.</string>
+    <string name="pref_aurora_library_swipe_switches_categories">Свайп переключает категории</string>
+    <string name="pref_aurora_library_swipe_switches_categories_summary">Горизонтальные свайпы в библиотеке переключают категории вместо разделов (аниме/манга/ранобэ).</string>
     <string name="label_player_settings">Настройки проигрывателя</string>
     <string name="action_search_player_settings">Поиск по настройкам проигрывателя</string>
     <string name="pref_player_internal">Внутренний проигрыватель</string>


### PR DESCRIPTION
## Summary

Adds an Aurora-only library toggle that redirects horizontal swipes on the library screen to switch between **categories** instead of between **sections** (anime / manga / novels). Default is **off**, so behavior is unchanged unless the user opts in.

- New `aurora_library_swipe_switches_categories` boolean preference (default `false`) in `UiPreferences`.
- New `onPagerSwipeOverride: ((forward: Boolean) -> Boolean)?` parameter on `TabbedScreenAurora`. When non-null:
  - The internal `HorizontalPager` has `userScrollEnabled = false`, so it no longer flings between sections.
  - A `pointerInput` block uses `detectHorizontalDragGestures` and, on drag end, calls the override with `forward = totalDragPx < 0f` (swipe-left = next).
  - If the override returns `false` (caller is at an edge), the existing edge-bounce visual is reused for feedback.
- `AnimeLibraryTab` reads the new preference and builds the override lambda that increments/decrements the current Aurora section's category index via the existing `onAuroraCategorySelected`. The override is `null` when the preference is off, when there is no current section, or when there are fewer than 2 categories — in those cases the pager keeps its normal section-swipe behavior.
- Adds the toggle to *Settings → Library → Aurora* group, next to the existing immersive-mode switch.
- Adds English (base) and Russian translations:
  - `pref_aurora_library_swipe_switches_categories` — `Swipe switches categories` / `Свайп переключает категории`
  - `pref_aurora_library_swipe_switches_categories_summary` — `Use horizontal swipes on the library to switch between categories instead of sections (anime/manga/novels).` / `Горизонтальные свайпы в библиотеке переключают категории вместо разделов (аниме/манга/ранобэ).`
- Adds a defaults unit test for the new preference in `UiPreferencesImmersiveModeTest`.

## Validation

- [x] `./gradlew :app:compileDebugKotlin :core:common:compileDebugKotlin` — green.
- [x] `./gradlew :app:testDebugUnitTest --tests "eu.kanade.domain.ui.UiPreferencesImmersiveModeTest"` — green (new + existing test).
- [x] `./gradlew :app:testDebugUnitTest --tests "eu.kanade.presentation.components.AuroraInstantTabSwitchingTest"` — green (existing instant-tab gesture tests still pass; my code path is the pager branch only).
- [ ] `./gradlew :app:spotlessCheck` — fails on pre-existing violations in `NovelJsSource.kt` / `NovelJsSourceTest.kt` on `ranobe-novel` (per the env-config note); my files pass `spotlessApply` cleanly.
- [x] I self-reviewed the diff. The new parameter is fully backward-compatible (default `null`), so the other call sites of `TabbedScreenAurora` (`HomeHubTab`, `BrowseTab`, `UpdatesTab`, `StatsTab`, `HistoriesTab`, `CategoriesTab`) are unaffected.

Requested by: @andarcanum