### PR TITLE
[browse] keep sources search bar visible when query yields no results

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/anime/AnimeSourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/anime/AnimeSourcesScreen.kt
@@ -79,9 +79,10 @@ fun AnimeSourcesScreen(
     } else {
         colors.cardBackground
     }
+    val hasSearchQuery = !searchQuery.isNullOrBlank()
     when {
         state.isLoading -> LoadingScreen(Modifier.padding(contentPadding))
-        state.isEmpty -> EmptyScreen(
+        state.isEmpty && !hasSearchQuery -> EmptyScreen(
             stringRes = MR.strings.source_empty_screen,
             modifier = Modifier.padding(contentPadding),
         )
@@ -156,6 +157,17 @@ fun AnimeSourcesScreen(
                                     singleLine = true,
                                 )
                             }
+                        }
+                    }
+                }
+
+                if (state.isEmpty) {
+                    item(key = "no-results") {
+                        Box(
+                            modifier = Modifier.fillParentMaxHeight(),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            EmptyScreen(stringRes = MR.strings.no_results_found)
                         }
                     }
                 }

--- a/app/src/main/java/eu/kanade/presentation/browse/manga/MangaSourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/manga/MangaSourcesScreen.kt
@@ -80,9 +80,10 @@ fun MangaSourcesScreen(
     } else {
         colors.cardBackground
     }
+    val hasSearchQuery = !searchQuery.isNullOrBlank()
     when {
         state.isLoading -> LoadingScreen(Modifier.padding(contentPadding))
-        state.isEmpty -> EmptyScreen(
+        state.isEmpty && !hasSearchQuery -> EmptyScreen(
             stringRes = MR.strings.source_empty_screen,
             modifier = Modifier.padding(contentPadding),
         )
@@ -157,6 +158,17 @@ fun MangaSourcesScreen(
                                     singleLine = true,
                                 )
                             }
+                        }
+                    }
+                }
+
+                if (state.isEmpty) {
+                    item(key = "no-results") {
+                        Box(
+                            modifier = Modifier.fillParentMaxHeight(),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            EmptyScreen(stringRes = MR.strings.no_results_found)
                         }
                     }
                 }

--- a/app/src/main/java/eu/kanade/presentation/browse/novel/NovelSourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/novel/NovelSourcesScreen.kt
@@ -78,9 +78,10 @@ fun NovelSourcesScreen(
     } else {
         colors.cardBackground
     }
+    val hasSearchQuery = !searchQuery.isNullOrBlank()
     when {
         state.isLoading -> LoadingScreen(Modifier.padding(contentPadding))
-        state.isEmpty -> EmptyScreen(
+        state.isEmpty && !hasSearchQuery -> EmptyScreen(
             stringRes = MR.strings.source_empty_screen,
             modifier = Modifier.padding(contentPadding),
         )
@@ -152,6 +153,17 @@ fun NovelSourcesScreen(
                                     singleLine = true,
                                 )
                             }
+                        }
+                    }
+                }
+
+                if (state.isEmpty) {
+                    item(key = "no-results") {
+                        Box(
+                            modifier = Modifier.fillParentMaxHeight(),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            EmptyScreen(stringRes = MR.strings.no_results_found)
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Fixes #88.

On the Browse → Anime / Manga / Novel **Sources** sub-tabs, the in-tab search bar is rendered as the first item of the LazyColumn that lists sources. When the user typed a query that filtered out every installed source, `state.isEmpty` (which is `items.isEmpty() && pinnedItems.isEmpty()`) became `true`, and the whole LazyColumn was replaced by an `EmptyScreen` showing "No source found". The screen-model still held the typed query, but the search bar was gone — so there was no way to clear the query short of force-stopping and relaunching the app.

This change splits the empty state into two cases:
- `state.isEmpty` **and** no search query is active → keep the existing "No source found" `EmptyScreen` (truly nothing to show).
- `state.isEmpty` **and** the user is currently searching → render the LazyColumn with the search bar at the top plus a centered "No results found" placeholder item that fills the rest of the page. The close (X) button on the search bar then clears the query and the source list reappears.

The same fix is applied symmetrically to all three Sources screens.

### Files changed

- `app/src/main/java/eu/kanade/presentation/browse/anime/AnimeSourcesScreen.kt`
- `app/src/main/java/eu/kanade/presentation/browse/manga/MangaSourcesScreen.kt`
- `app/src/main/java/eu/kanade/presentation/browse/novel/NovelSourcesScreen.kt`

No new strings were added — reuses the existing `MR.strings.no_results_found` and `MR.strings.source_empty_screen`.

## Validation

- [x] `./gradlew :app:compileDebugKotlin` — BUILD SUCCESSFUL
- [x] `./gradlew :app:spotlessCheck` — BUILD SUCCESSFUL


Link to Devin session: https://app.devin.ai/sessions/8dc968d4bba241aea57ea2122a3c15a8
Requested by: @andarcanum