### PR TITLE
[library] keep Aurora category selection across pushed entry screens

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/anime/AnimeLibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/anime/AnimeLibraryTab.kt
@@ -457,18 +457,34 @@ data object AnimeLibraryTab : Tab {
         }
 
         LaunchedEffect(state.categories.size, animeCategoryIndex) {
-            if (screenModel.activeCategoryIndex != animeCategoryIndex) {
+            if (shouldSyncAuroraLibraryCategoryIndex(
+                    categoryCount = state.categories.size,
+                    currentIndex = screenModel.activeCategoryIndex,
+                    targetIndex = animeCategoryIndex,
+                )
+            ) {
                 screenModel.activeCategoryIndex = animeCategoryIndex
             }
         }
         LaunchedEffect(mangaState.categories.size, mangaCategoryIndex) {
-            if (mangaScreenModel.activeCategoryIndex != mangaCategoryIndex) {
+            if (shouldSyncAuroraLibraryCategoryIndex(
+                    categoryCount = mangaState.categories.size,
+                    currentIndex = mangaScreenModel.activeCategoryIndex,
+                    targetIndex = mangaCategoryIndex,
+                )
+            ) {
                 mangaScreenModel.activeCategoryIndex = mangaCategoryIndex
             }
         }
         LaunchedEffect(novelCategories.size, novelCategoryIndex) {
-            if (novelScreenModel?.activeCategoryIndex != novelCategoryIndex) {
-                novelScreenModel?.activeCategoryIndex = novelCategoryIndex
+            val activeNovelScreenModel = novelScreenModel ?: return@LaunchedEffect
+            if (shouldSyncAuroraLibraryCategoryIndex(
+                    categoryCount = novelCategories.size,
+                    currentIndex = activeNovelScreenModel.activeCategoryIndex,
+                    targetIndex = novelCategoryIndex,
+                )
+            ) {
+                activeNovelScreenModel.activeCategoryIndex = novelCategoryIndex
             }
         }
 
@@ -1904,6 +1920,21 @@ internal fun shouldShowAuroraSearchField(
 internal fun coerceAuroraLibraryCategoryIndex(requestedIndex: Int, categoryCount: Int): Int {
     if (categoryCount <= 0) return 0
     return requestedIndex.coerceIn(0, categoryCount - 1)
+}
+
+/**
+ * Decides whether the Aurora library should propagate a category index back to the section's
+ * screen model. We must skip the sync while the category list has not been loaded yet (e.g. right
+ * after returning from a pushed entry screen, when category flows briefly emit an empty initial
+ * value), otherwise the screen model would be permanently reset to the first category.
+ */
+internal fun shouldSyncAuroraLibraryCategoryIndex(
+    categoryCount: Int,
+    currentIndex: Int,
+    targetIndex: Int,
+): Boolean {
+    if (categoryCount <= 0) return false
+    return currentIndex != targetIndex
 }
 
 private fun NovelCategory.toCategory(): Category {

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/library/anime/AnimeLibraryAuroraHeaderStateTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/library/anime/AnimeLibraryAuroraHeaderStateTest.kt
@@ -47,6 +47,39 @@ class AnimeLibraryAuroraHeaderStateTest {
     }
 
     @Test
+    fun `shouldSyncAuroraLibraryCategoryIndex skips sync while categories are not loaded`() {
+        shouldSyncAuroraLibraryCategoryIndex(
+            categoryCount = 0,
+            currentIndex = 2,
+            targetIndex = 0,
+        ) shouldBe false
+
+        shouldSyncAuroraLibraryCategoryIndex(
+            categoryCount = -1,
+            currentIndex = 0,
+            targetIndex = 0,
+        ) shouldBe false
+    }
+
+    @Test
+    fun `shouldSyncAuroraLibraryCategoryIndex syncs when current and target diverge`() {
+        shouldSyncAuroraLibraryCategoryIndex(
+            categoryCount = 3,
+            currentIndex = 5,
+            targetIndex = 2,
+        ) shouldBe true
+    }
+
+    @Test
+    fun `shouldSyncAuroraLibraryCategoryIndex skips sync when already aligned`() {
+        shouldSyncAuroraLibraryCategoryIndex(
+            categoryCount = 3,
+            currentIndex = 1,
+            targetIndex = 1,
+        ) shouldBe false
+    }
+
+    @Test
     fun `shouldShowAuroraLibraryCategoryTabsRow matches legacy tab visibility rules`() {
         shouldShowAuroraLibraryCategoryTabsRow(
             section = AnimeLibraryTab.Section.Anime,


### PR DESCRIPTION
## Summary

Fixes #93.

When the Novel section's category was anything other than the first one, opening any entry and popping back to the library reset the selection to the first category — the only way to recover was to swipe through the categories (or restart the app).

### Root cause

In `AnimeLibraryTab` (the unified Aurora library tab), the Novel section pulls its category list from a domain flow:

```kotlin
val visibleNovelCategories by getVisibleNovelCategories.subscribe()
    .collectAsState(initial = emptyList())
```

Unlike Anime/Manga, whose `state.categories` is sourced from the screen-model `StateFlow` (which holds the latest emitted value), `getVisibleNovelCategories.subscribe()` is a regular `Flow`. After `navigator.push(NovelScreen(...))` and a subsequent `pop`, `AnimeLibraryTab` is re-composed from scratch and `collectAsState` emits its `initial` value (`emptyList()`) before the flow re-delivers the real categories.

While that empty list was in effect, the existing logic was:

```kotlin
val novelCategoryIndex = coerceAuroraLibraryCategoryIndex(
    requestedIndex = novelScreenModel?.activeCategoryIndex ?: 0,
    categoryCount = novelCategories.size, // == 0 for one frame
)
LaunchedEffect(novelCategories.size, novelCategoryIndex) {
    if (novelScreenModel?.activeCategoryIndex != novelCategoryIndex) {
        novelScreenModel?.activeCategoryIndex = novelCategoryIndex // writes 0!
    }
}
```

Because `coerceAuroraLibraryCategoryIndex(_, 0)` returns `0`, the LaunchedEffect propagated `0` into `NovelLibraryScreenModel.activeCategoryIndex`. By the time the real category list arrived, the index had already been clamped to the first category and the user was stuck on it for the rest of the session.

### Fix

Introduce a small helper that simply refuses to sync while the category list is not loaded yet:

```kotlin
internal fun shouldSyncAuroraLibraryCategoryIndex(
    categoryCount: Int,
    currentIndex: Int,
    targetIndex: Int,
): Boolean {
    if (categoryCount <= 0) return false
    return currentIndex != targetIndex
}
```

All three Aurora `LaunchedEffect`s (anime, manga, novel) now go through this helper. Anime/Manga were less likely to trip the race because their categories live on a `StateFlow`, but they followed the same fragile pattern, so the guard is applied symmetrically.

No behavior change once the categories are populated:
- diverging current/target → still propagated (e.g. when an entire category is deleted and the active index becomes out of range)
- aligned current/target → no-op
- empty/loading category list → leave the screen-model value alone

### Files changed

- `app/src/main/java/eu/kanade/tachiyomi/ui/library/anime/AnimeLibraryTab.kt` — add helper, route three LaunchedEffects through it.
- `app/src/test/java/eu/kanade/tachiyomi/ui/library/anime/AnimeLibraryAuroraHeaderStateTest.kt` — three new unit tests for the helper.

## Validation

- [x] `./gradlew :app:compileDebugKotlin` — BUILD SUCCESSFUL
- [x] `./gradlew :app:spotlessCheck` — BUILD SUCCESSFUL
- [x] `./gradlew :app:testDebugUnitTest --tests "...AnimeLibraryAuroraHeaderStateTest"` — all 12 tests passed (9 existing + 3 new).
- [x] Self-reviewed the diff (2 files, +68/-4).

Requested by: @andarcanum