### PR TITLE
Fix browse extension search toolbar state

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/components/TabbedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/components/TabbedScreen.kt
@@ -69,6 +69,13 @@ fun TabbedScreen(
                     else -> onChangeAnimeSearchQuery
                 }
 
+                val searchQuery = if (tab.onChangeSearchQuery != null) {
+                    tab.searchQuery
+                } else {
+                    actualQuery
+                }
+                val onChangeSearchQuery = tab.onChangeSearchQuery ?: actualOnChange
+
                 SearchToolbar(
                     titleContent = {
                         AppBarTitle(
@@ -80,8 +87,8 @@ fun TabbedScreen(
                     },
                     searchEnabled = searchEnabled,
                     searchActionIconTint = searchActionIconTint,
-                    searchQuery = if (searchEnabled) actualQuery else null,
-                    onChangeSearchQuery = actualOnChange,
+                    searchQuery = if (searchEnabled) searchQuery else null,
+                    onChangeSearchQuery = onChangeSearchQuery,
                     actions = {
                         if (tab.actions.isNotEmpty()) {
                             Spacer(modifier = Modifier.width(4.dp + extraSearchToActionsGap))
@@ -138,6 +145,8 @@ data class TabContent(
     val titleRes: StringResource,
     val badgeNumber: Int? = null,
     val searchEnabled: Boolean = false,
+    val searchQuery: String? = null,
+    val onChangeSearchQuery: ((String?) -> Unit)? = null,
     val actions: ImmutableList<AppBar.AppBarAction> = persistentListOf(),
     val content: @Composable (contentPadding: PaddingValues, snackbarHostState: SnackbarHostState) -> Unit,
     val numberTitle: Int = 0,

--- a/app/src/main/java/eu/kanade/presentation/components/TabbedScreenAurora.kt
+++ b/app/src/main/java/eu/kanade/presentation/components/TabbedScreenAurora.kt
@@ -140,8 +140,16 @@ fun TabbedScreenAurora(
     }
 
     val isMangaPage = isMangaTab(currentPage)
-    val activeSearchQuery = if (isMangaPage) mangaSearchQuery else animeSearchQuery
-    val onChangeSearchQuery = if (isMangaPage) onChangeMangaSearchQuery else onChangeAnimeSearchQuery
+    val currentTab = tabs.getOrNull(currentPage)
+    val activeSearchQuery = if (currentTab?.onChangeSearchQuery != null) {
+        currentTab.searchQuery
+    } else if (isMangaPage) {
+        mangaSearchQuery
+    } else {
+        animeSearchQuery
+    }
+    val onChangeSearchQuery = currentTab?.onChangeSearchQuery
+        ?: if (isMangaPage) onChangeMangaSearchQuery else onChangeAnimeSearchQuery
     val isSearchActive = activeSearchQuery != null
 
     val colors = AuroraTheme.colors

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/anime/extension/AnimeExtensionsTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/anime/extension/AnimeExtensionsTab.kt
@@ -39,6 +39,8 @@ fun animeExtensionsTab(
         titleRes = AYMR.strings.label_anime_extensions,
         badgeNumber = state.updates.takeIf { it > 0 },
         searchEnabled = true,
+        searchQuery = state.searchQuery,
+        onChangeSearchQuery = extensionsScreenModel::search,
         actions = persistentListOf(
             AppBar.OverflowAction(
                 title = stringResource(MR.strings.action_filter),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/extension/MangaExtensionsTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/extension/MangaExtensionsTab.kt
@@ -39,6 +39,8 @@ fun mangaExtensionsTab(
         titleRes = AYMR.strings.label_manga_extensions,
         badgeNumber = state.updates.takeIf { it > 0 },
         searchEnabled = true,
+        searchQuery = state.searchQuery,
+        onChangeSearchQuery = extensionsScreenModel::search,
         actions = persistentListOf(
             AppBar.OverflowAction(
                 title = stringResource(MR.strings.action_filter),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/novel/extension/NovelExtensionsTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/novel/extension/NovelExtensionsTab.kt
@@ -34,6 +34,8 @@ fun novelExtensionsTab(
         titleRes = AYMR.strings.label_novel_extensions,
         badgeNumber = state.updates.takeIf { it > 0 },
         searchEnabled = true,
+        searchQuery = state.searchQuery,
+        onChangeSearchQuery = extensionsScreenModel::search,
         actions = persistentListOf(
             AppBar.OverflowAction(
                 title = stringResource(MR.strings.action_filter),

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/browse/novel/extension/NovelExtensionsScreenModelTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/browse/novel/extension/NovelExtensionsScreenModelTest.kt
@@ -168,6 +168,32 @@ class NovelExtensionsScreenModelTest {
     }
 
     @Test
+    fun `empty search results keep query so toolbar stays active`() {
+        runBlocking {
+            val screenModel = NovelExtensionsScreenModel(
+                extensionManager = FakeNovelExtensionManager(
+                    installed = emptyList(),
+                    available = listOf(pluginAvailable("id-1", 1)),
+                    updates = emptyList(),
+                ),
+                sourcePreferences = sourcePreferences,
+            ).also(activeScreenModels::add)
+
+            withTimeout(1_000) {
+                while (screenModel.state.value.isLoading) {
+                    yield()
+                }
+            }
+
+            screenModel.search("missing")
+            delay(SEARCH_DEBOUNCE_MILLIS + 50)
+
+            screenModel.state.value.items shouldBe emptyList()
+            screenModel.state.value.searchQuery shouldBe "missing"
+        }
+    }
+
+    @Test
     fun `available plugins are filtered by enabled language`() {
         runBlocking {
             val english = pluginAvailable("id-en", 1).copy(lang = "en")


### PR DESCRIPTION
## Summary

- Fixes #88 by letting each browse extension tab own its search query/handler instead of relying on section-level two-way routing.
- Keeps the extension search toolbar active when a search returns no results, so users can clear or edit the query without force-stopping the app.
- Adds a novel extension screen-model regression test for empty search results preserving the active query.

## Validation

- [x] I ran the required automated checks for this change.
- [x] I self-reviewed the diff and validated critical user flows.

Checks run locally:
- `ANDROID_HOME="$HOME/android-sdk" ./gradlew :app:testDebugUnitTest --tests eu.kanade.tachiyomi.ui.browse.novel.extension.NovelExtensionsScreenModelTest :app:compileDebugKotlin`
- `ANDROID_HOME="$HOME/android-sdk" ./gradlew :app:testDebugUnitTest --tests eu.kanade.tachiyomi.ui.reader.novel.NovelReaderScreenModelTest.completed\ gemini\ queue\ updates\ restore\ cached\ translation\ into\ reader` (reran isolated unrelated CI failure; passed locally)


Requested by: @andarcanum