### PR TITLE
[library] restore Aurora category selector colour in dark mode

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/anime/AnimeLibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/anime/AnimeLibraryTab.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
@@ -1814,17 +1815,21 @@ private fun AuroraLibraryCategoryTabs(
             ) { index, category ->
                 val isSelected = index == coercedSelected
                 val badgeCount = getCountForCategory(category)
-                val tabBackground = when {
-                    isSelected && colors.isDark -> Color.White.copy(alpha = 0.16f)
-                    isSelected -> colors.accentVariant
-                    colors.isDark -> Color.Transparent
-                    else -> colors.cardBackground
-                }
+                val tabColors = auroraLibraryCategoryTabColors(
+                    isSelected = isSelected,
+                    isDark = colors.isDark,
+                    accent = colors.accent,
+                    accentVariant = colors.accentVariant,
+                    glass = colors.glass,
+                    cardBackground = colors.cardBackground,
+                    textPrimary = colors.textPrimary,
+                    textSecondary = colors.textSecondary,
+                )
 
                 Row(
                     modifier = Modifier
                         .clip(RoundedCornerShape(18.dp))
-                        .background(tabBackground)
+                        .background(tabColors.tabBackground)
                         .clickable {
                             appHaptics.tap()
                             onCategorySelected(index)
@@ -1835,7 +1840,7 @@ private fun AuroraLibraryCategoryTabs(
                 ) {
                     Text(
                         text = category.visualName,
-                        color = if (isSelected) colors.textPrimary else colors.textSecondary,
+                        color = tabColors.tabTextColor,
                         fontSize = 13.sp,
                         fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Medium,
                         maxLines = 1,
@@ -1846,18 +1851,14 @@ private fun AuroraLibraryCategoryTabs(
                         Box(
                             modifier = Modifier
                                 .background(
-                                    color = if (isSelected) {
-                                        colors.accent
-                                    } else {
-                                        colors.cardBackground
-                                    },
+                                    color = tabColors.badgeBackground,
                                     shape = RoundedCornerShape(10.dp),
                                 )
                                 .padding(horizontal = 6.dp, vertical = 2.dp),
                         ) {
                             Text(
                                 text = badgeCount.toString(),
-                                color = if (isSelected) colors.textOnAccent else colors.textSecondary,
+                                color = tabColors.badgeTextColor,
                                 fontSize = 10.sp,
                                 fontWeight = FontWeight.SemiBold,
                                 maxLines = 1,
@@ -1920,6 +1921,56 @@ internal fun shouldShowAuroraSearchField(
 internal fun coerceAuroraLibraryCategoryIndex(requestedIndex: Int, categoryCount: Int): Int {
     if (categoryCount <= 0) return 0
     return requestedIndex.coerceIn(0, categoryCount - 1)
+}
+
+/**
+ * Pure colour computation for a single Aurora library category tab + its count badge.
+ *
+ * Goals:
+ *  - Selected tab carries a clear accent presence in BOTH themes (so the selection is obvious in
+ *    dark mode, where it used to fall back to a flat translucent-white pill with no accent).
+ *  - The badge inside a selected tab is a neutral chip that contrasts with the accent-tinted tab,
+ *    instead of stacking another accent fill on top of an accent surface.
+ *  - The badge inside an unselected tab is also distinguishable from the tab background, so the
+ *    count chip is readable even when the tab itself is inactive.
+ */
+internal data class AuroraLibraryCategoryTabColors(
+    val tabBackground: Color,
+    val badgeBackground: Color,
+    val tabTextColor: Color,
+    val badgeTextColor: Color,
+)
+
+internal fun auroraLibraryCategoryTabColors(
+    isSelected: Boolean,
+    isDark: Boolean,
+    accent: Color,
+    accentVariant: Color,
+    glass: Color,
+    cardBackground: Color,
+    textPrimary: Color,
+    textSecondary: Color,
+): AuroraLibraryCategoryTabColors {
+    val tabBackground = when {
+        isSelected && isDark -> accent.copy(alpha = 0.22f).compositeOver(glass)
+        isSelected -> accentVariant
+        isDark -> Color.Transparent
+        else -> cardBackground
+    }
+    val badgeBackground = when {
+        isSelected && isDark -> Color.White.copy(alpha = 0.20f)
+        isSelected -> Color.White
+        isDark -> cardBackground
+        else -> Color.White
+    }
+    val tabTextColor = if (isSelected) textPrimary else textSecondary
+    val badgeTextColor = if (isSelected) textPrimary else textSecondary
+    return AuroraLibraryCategoryTabColors(
+        tabBackground = tabBackground,
+        badgeBackground = badgeBackground,
+        tabTextColor = tabTextColor,
+        badgeTextColor = badgeTextColor,
+    )
 }
 
 /**

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/library/anime/AnimeLibraryAuroraHeaderStateTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/library/anime/AnimeLibraryAuroraHeaderStateTest.kt
@@ -1,9 +1,23 @@
 package eu.kanade.tachiyomi.ui.library.anime
 
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import org.junit.jupiter.api.Test
 
 class AnimeLibraryAuroraHeaderStateTest {
+
+    private val testAccent = Color(0xFF3366FF)
+    private val testAccentVariant = Color(0xFFD0D9FF)
+    private val testGlassDark = Color.White.copy(alpha = 0.22f)
+    private val testGlassLight = Color(0xE6FFFFFF)
+    private val testCardBackgroundDark = Color.White.copy(alpha = 0.12f)
+    private val testCardBackgroundLight = Color(0xFFF0F4F8)
+    private val testTextPrimaryDark = Color.White
+    private val testTextPrimaryLight = Color(0xFF0F172A)
+    private val testTextSecondaryDark = Color.White.copy(alpha = 0.7f)
+    private val testTextSecondaryLight = Color(0xFF475569)
 
     @Test
     fun `resolveAuroraLibrarySection returns matching section for page`() {
@@ -77,6 +91,103 @@ class AnimeLibraryAuroraHeaderStateTest {
             currentIndex = 1,
             targetIndex = 1,
         ) shouldBe false
+    }
+
+    @Test
+    fun `auroraLibraryCategoryTabColors selected dark tab carries accent tint over glass`() {
+        val colors = auroraLibraryCategoryTabColors(
+            isSelected = true,
+            isDark = true,
+            accent = testAccent,
+            accentVariant = testAccentVariant,
+            glass = testGlassDark,
+            cardBackground = testCardBackgroundDark,
+            textPrimary = testTextPrimaryDark,
+            textSecondary = testTextSecondaryDark,
+        )
+
+        colors.tabBackground shouldBe testAccent.copy(alpha = 0.22f).compositeOver(testGlassDark)
+        colors.badgeBackground shouldBe Color.White.copy(alpha = 0.20f)
+        colors.tabTextColor shouldBe testTextPrimaryDark
+        colors.badgeTextColor shouldBe testTextPrimaryDark
+    }
+
+    @Test
+    fun `auroraLibraryCategoryTabColors selected light tab uses accent variant with neutral badge`() {
+        val colors = auroraLibraryCategoryTabColors(
+            isSelected = true,
+            isDark = false,
+            accent = testAccent,
+            accentVariant = testAccentVariant,
+            glass = testGlassLight,
+            cardBackground = testCardBackgroundLight,
+            textPrimary = testTextPrimaryLight,
+            textSecondary = testTextSecondaryLight,
+        )
+
+        colors.tabBackground shouldBe testAccentVariant
+        colors.badgeBackground shouldBe Color.White
+        colors.tabTextColor shouldBe testTextPrimaryLight
+        colors.badgeTextColor shouldBe testTextPrimaryLight
+    }
+
+    @Test
+    fun `auroraLibraryCategoryTabColors unselected dark tab is transparent with subtle badge`() {
+        val colors = auroraLibraryCategoryTabColors(
+            isSelected = false,
+            isDark = true,
+            accent = testAccent,
+            accentVariant = testAccentVariant,
+            glass = testGlassDark,
+            cardBackground = testCardBackgroundDark,
+            textPrimary = testTextPrimaryDark,
+            textSecondary = testTextSecondaryDark,
+        )
+
+        colors.tabBackground shouldBe Color.Transparent
+        colors.badgeBackground shouldBe testCardBackgroundDark
+        colors.tabTextColor shouldBe testTextSecondaryDark
+        colors.badgeTextColor shouldBe testTextSecondaryDark
+    }
+
+    @Test
+    fun `auroraLibraryCategoryTabColors unselected light tab uses neutral surface but white badge`() {
+        val colors = auroraLibraryCategoryTabColors(
+            isSelected = false,
+            isDark = false,
+            accent = testAccent,
+            accentVariant = testAccentVariant,
+            glass = testGlassLight,
+            cardBackground = testCardBackgroundLight,
+            textPrimary = testTextPrimaryLight,
+            textSecondary = testTextSecondaryLight,
+        )
+
+        colors.tabBackground shouldBe testCardBackgroundLight
+        // White chip on the very-light cardBackground keeps the badge readable.
+        colors.badgeBackground shouldBe Color.White
+        colors.badgeBackground shouldNotBe colors.tabBackground
+        colors.tabTextColor shouldBe testTextSecondaryLight
+        colors.badgeTextColor shouldBe testTextSecondaryLight
+    }
+
+    @Test
+    fun `auroraLibraryCategoryTabColors selected light badge no longer stacks accent on accent`() {
+        val colors = auroraLibraryCategoryTabColors(
+            isSelected = true,
+            isDark = false,
+            accent = testAccent,
+            accentVariant = testAccentVariant,
+            glass = testGlassLight,
+            cardBackground = testCardBackgroundLight,
+            textPrimary = testTextPrimaryLight,
+            textSecondary = testTextSecondaryLight,
+        )
+
+        // Regression guard for issue: selected light badge must NOT be the accent itself,
+        // otherwise it visually merges with the accentVariant tab background.
+        colors.badgeBackground shouldNotBe testAccent
+        colors.badgeBackground shouldNotBe testAccentVariant
     }
 
     @Test


### PR DESCRIPTION
## Summary

Reported in chat: in the Aurora library, the category selector had two visual problems:

- **Dark theme**: selecting a category fell back to a flat translucent-white pill (`Color.White × 0.16f`) and the accent was missing entirely.
- **Light theme**: the count badge inside the selected tab was filled with `colors.accent` while the tab itself was already `colors.accentVariant`, so two accent surfaces stacked on top of each other and the badge merged into the tab.

This PR rewires `AuroraLibraryCategoryTabs` so the selected state carries a clear accent presence in **both** themes, and the count badge becomes a neutral chip that contrasts with the accent-tinted tab instead of doubling the accent.

### Approach

Extracted a pure helper `auroraLibraryCategoryTabColors(...)` so the colour decisions can be tested without spinning up Compose. The composable now reads:

```kotlin
val tabColors = auroraLibraryCategoryTabColors(
    isSelected = isSelected,
    isDark = colors.isDark,
    accent = colors.accent,
    accentVariant = colors.accentVariant,
    glass = colors.glass,
    cardBackground = colors.cardBackground,
    textPrimary = colors.textPrimary,
    textSecondary = colors.textSecondary,
)
```

The mapping is:

| State | Theme | Tab background | Badge background | Tab text | Badge text |
|---|---|---|---|---|---|
| selected | dark | `accent × 0.22f` composited over `glass` | `Color.White × 0.20f` | `textPrimary` | `textPrimary` |
| selected | light | `accentVariant` | `Color.White` | `textPrimary` | `textPrimary` |
| unselected | dark | `Color.Transparent` | `cardBackground` | `textSecondary` | `textSecondary` |
| unselected | light | `cardBackground` | `Color.White` | `textSecondary` | `textSecondary` |

Notes:
- Selected dark tab now reads as an accent-tinted pill instead of a plain white tint, so the user can see which category is active.
- Selected light badge no longer reuses `accent` on top of `accentVariant`; a solid white chip with `textPrimary` digits sits cleanly on the soft accent surface.
- Unselected light badge changed from `cardBackground` to `Color.White` so the count chip is visible against the same `cardBackground` tab fill (previously the chip was the same colour as the tab).
- Selected text is now `textPrimary` for both themes (was already `textPrimary` for the tab label, but the badge digits are no longer `textOnAccent` since the badge is no longer accent-coloured).

### Files changed

- `app/src/main/java/eu/kanade/tachiyomi/ui/library/anime/AnimeLibraryTab.kt` — extract `AuroraLibraryCategoryTabColors` data class + `auroraLibraryCategoryTabColors()` helper, route `AuroraLibraryCategoryTabs` through it, add `compositeOver` import.
- `app/src/test/java/eu/kanade/tachiyomi/ui/library/anime/AnimeLibraryAuroraHeaderStateTest.kt` — five new unit tests covering selected/unselected × dark/light, plus a regression guard that the selected light badge never falls back to `accent` or `accentVariant`.

## Validation

- [x] `./gradlew :app:compileDebugKotlin` — BUILD SUCCESSFUL.
- [x] `./gradlew :app:spotlessCheck` — BUILD SUCCESSFUL.
- [x] `./gradlew :app:testDebugUnitTest --tests "...AnimeLibraryAuroraHeaderStateTest"` — all 17 tests passed (12 existing + 5 new).
- [x] Self-reviewed the diff (2 files, +176/-14).


Requested by: @andarcanum