### PR TITLE
[home] stop bottom navigation from cutting off the last LazyColumn items

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/components/TabbedScreenAurora.kt
+++ b/app/src/main/java/eu/kanade/presentation/components/TabbedScreenAurora.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -66,6 +68,7 @@ import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.Hyphens
@@ -73,6 +76,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.icerock.moko.resources.StringResource
@@ -97,6 +101,33 @@ data class TabState(
     val onTabSelected: (Int) -> Unit,
 )
 val LocalTabState = compositionLocalOf<TabState?> { null }
+
+/**
+ * Surface to propagate the host Scaffold's [PaddingValues] (most importantly its bottom inset that
+ * accounts for the in-app NavigationBar height) down to every tab content rendered through
+ * [TabbedScreenAurora]. The host (e.g. `HomeScreen`) intentionally extends the body under the
+ * bottomBar for an edge-to-edge look, so without this hook every tab's LazyColumn would scroll
+ * its last items behind the bar.
+ *
+ * `null` means there is no host padding (e.g. preview/test) and consumers should fall back to a
+ * sensible default.
+ */
+val LocalHostScaffoldContentPadding = compositionLocalOf<PaddingValues?> { null }
+
+internal fun resolveTabbedScreenAuroraContentPadding(
+    hostContentPadding: PaddingValues?,
+    layoutDirection: LayoutDirection,
+    extraBottom: Dp = 16.dp,
+): PaddingValues {
+    val hostBottom = hostContentPadding?.calculateBottomPadding() ?: 0.dp
+    val hostStart = hostContentPadding?.calculateStartPadding(layoutDirection) ?: 0.dp
+    val hostEnd = hostContentPadding?.calculateEndPadding(layoutDirection) ?: 0.dp
+    return PaddingValues(
+        start = hostStart,
+        end = hostEnd,
+        bottom = hostBottom + extraBottom,
+    )
+}
 
 @Composable
 fun TabbedScreenAurora(
@@ -203,6 +234,12 @@ fun TabbedScreenAurora(
 
         previousInstantTabSwitching = instantTabSwitching
     }
+
+    val hostScaffoldContentPadding = LocalHostScaffoldContentPadding.current
+    val tabContentPadding = resolveTabbedScreenAuroraContentPadding(
+        hostContentPadding = hostScaffoldContentPadding,
+        layoutDirection = LocalLayoutDirection.current,
+    )
 
     AuroraBackground(
         modifier = modifier,
@@ -319,7 +356,7 @@ fun TabbedScreenAurora(
                         key(page) {
                             CompositionLocalProvider(LocalTabState provides tabState) {
                                 tabs[page].content(
-                                    PaddingValues(bottom = 16.dp),
+                                    tabContentPadding,
                                     snackbarHostState,
                                 )
                             }
@@ -393,7 +430,7 @@ fun TabbedScreenAurora(
                                     .auroraCenteredMaxWidth(contentMaxWidthDp),
                             ) {
                                 tabs[page].content(
-                                    PaddingValues(bottom = 16.dp),
+                                    tabContentPadding,
                                     snackbarHostState,
                                 )
                             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/home/HomeScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/home/HomeScreen.kt
@@ -56,6 +56,7 @@ import cafe.adriel.voyager.navigator.tab.TabNavigator
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.domain.ui.model.StartScreen
+import eu.kanade.presentation.components.LocalHostScaffoldContentPadding
 import eu.kanade.presentation.theme.AuroraTheme
 import eu.kanade.presentation.theme.LocalIsEInkMode
 import eu.kanade.presentation.util.BottomNavVisibilityController
@@ -250,67 +251,71 @@ object HomeScreen : Screen() {
                             .padding(top = contentPadding.calculateTopPadding())
                             .consumeWindowInsets(contentPadding),
                     ) {
-                        if (resolvedTransitionMode == ResolvedNavigationTransitionMode.NONE) {
-                            val currentTab = tabNavigator.current
-                            tabNavigator.saveableState(key = "currentTab", currentTab) {
-                                currentTab.Content()
-                            }
-                        } else {
-                            AnimatedContent(
-                                targetState = tabNavigator.current,
-                                transitionSpec = {
-                                    when (resolvedTransitionMode) {
-                                        ResolvedNavigationTransitionMode.NONE -> {
-                                            EnterTransition.None togetherWith ExitTransition.None
-                                        }
-                                        ResolvedNavigationTransitionMode.LEGACY -> {
-                                            materialFadeThroughIn(
-                                                initialScale = 1f,
-                                                durationMillis = TAB_FADE_DURATION,
-                                            ) togetherWith
-                                                materialFadeThroughOut(durationMillis = TAB_FADE_DURATION)
-                                        }
-                                        ResolvedNavigationTransitionMode.MODERN -> {
-                                            val direction = tabDirection(
-                                                initialTab = initialState,
-                                                targetTab = targetState,
-                                                currentMoreTab = currentMoreTab,
-                                                navStyle = navStyle,
-                                            )
-                                            val enter = slideInHorizontally(
-                                                animationSpec = tween(
-                                                    durationMillis = TAB_MODERN_ENTER_DURATION,
-                                                    easing = AURORA_EASING,
-                                                ),
-                                                initialOffsetX = { width -> direction * (width / 4) },
-                                            ) + fadeIn(
-                                                animationSpec = tween(
-                                                    durationMillis = TAB_MODERN_ENTER_DURATION,
-                                                    easing = AURORA_EASING,
-                                                ),
-                                            )
-                                            val exit = slideOutHorizontally(
-                                                animationSpec = tween(
-                                                    durationMillis = TAB_MODERN_EXIT_DURATION,
-                                                    easing = AURORA_EASING,
-                                                ),
-                                                targetOffsetX = { width -> -direction * (width / 5) },
-                                            ) + fadeOut(
-                                                animationSpec = tween(
-                                                    durationMillis = TAB_MODERN_EXIT_DURATION,
-                                                    easing = AURORA_EASING,
-                                                ),
-                                            )
-                                            (enter togetherWith exit).apply {
-                                                targetContentZIndex = 1f
-                                            }
-                                        }
-                                    }
-                                },
-                                label = "tabContent",
-                            ) { currentTab ->
+                        CompositionLocalProvider(
+                            LocalHostScaffoldContentPadding provides contentPadding,
+                        ) {
+                            if (resolvedTransitionMode == ResolvedNavigationTransitionMode.NONE) {
+                                val currentTab = tabNavigator.current
                                 tabNavigator.saveableState(key = "currentTab", currentTab) {
                                     currentTab.Content()
+                                }
+                            } else {
+                                AnimatedContent(
+                                    targetState = tabNavigator.current,
+                                    transitionSpec = {
+                                        when (resolvedTransitionMode) {
+                                            ResolvedNavigationTransitionMode.NONE -> {
+                                                EnterTransition.None togetherWith ExitTransition.None
+                                            }
+                                            ResolvedNavigationTransitionMode.LEGACY -> {
+                                                materialFadeThroughIn(
+                                                    initialScale = 1f,
+                                                    durationMillis = TAB_FADE_DURATION,
+                                                ) togetherWith
+                                                    materialFadeThroughOut(durationMillis = TAB_FADE_DURATION)
+                                            }
+                                            ResolvedNavigationTransitionMode.MODERN -> {
+                                                val direction = tabDirection(
+                                                    initialTab = initialState,
+                                                    targetTab = targetState,
+                                                    currentMoreTab = currentMoreTab,
+                                                    navStyle = navStyle,
+                                                )
+                                                val enter = slideInHorizontally(
+                                                    animationSpec = tween(
+                                                        durationMillis = TAB_MODERN_ENTER_DURATION,
+                                                        easing = AURORA_EASING,
+                                                    ),
+                                                    initialOffsetX = { width -> direction * (width / 4) },
+                                                ) + fadeIn(
+                                                    animationSpec = tween(
+                                                        durationMillis = TAB_MODERN_ENTER_DURATION,
+                                                        easing = AURORA_EASING,
+                                                    ),
+                                                )
+                                                val exit = slideOutHorizontally(
+                                                    animationSpec = tween(
+                                                        durationMillis = TAB_MODERN_EXIT_DURATION,
+                                                        easing = AURORA_EASING,
+                                                    ),
+                                                    targetOffsetX = { width -> -direction * (width / 5) },
+                                                ) + fadeOut(
+                                                    animationSpec = tween(
+                                                        durationMillis = TAB_MODERN_EXIT_DURATION,
+                                                        easing = AURORA_EASING,
+                                                    ),
+                                                )
+                                                (enter togetherWith exit).apply {
+                                                    targetContentZIndex = 1f
+                                                }
+                                            }
+                                        }
+                                    },
+                                    label = "tabContent",
+                                ) { currentTab ->
+                                    tabNavigator.saveableState(key = "currentTab", currentTab) {
+                                        currentTab.Content()
+                                    }
                                 }
                             }
                         }

--- a/app/src/test/java/eu/kanade/presentation/components/TabbedScreenAuroraContentPaddingTest.kt
+++ b/app/src/test/java/eu/kanade/presentation/components/TabbedScreenAuroraContentPaddingTest.kt
@@ -1,0 +1,86 @@
+package eu.kanade.presentation.components
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression tests for [resolveTabbedScreenAuroraContentPadding].
+ *
+ * The host (e.g. `HomeScreen`) intentionally extends the body under the in-app NavigationBar so it
+ * can render glassy/edge-to-edge surfaces. Without these calculations, every tab's LazyColumn
+ * would scroll its last items behind the bar — which on the Home screen "Recently Added" grid
+ * meant the title and chapter count were hidden by the bar even after scrolling all the way down.
+ */
+class TabbedScreenAuroraContentPaddingTest {
+
+    @Test
+    fun `falls back to extra bottom only when no host padding is provided`() {
+        val resolved = resolveTabbedScreenAuroraContentPadding(
+            hostContentPadding = null,
+            layoutDirection = LayoutDirection.Ltr,
+            extraBottom = 16.dp,
+        )
+
+        assertEquals(0.dp, resolved.calculateTopPadding())
+        assertEquals(16.dp, resolved.calculateBottomPadding())
+        assertEquals(0.dp, resolved.calculateStartPadding(LayoutDirection.Ltr))
+        assertEquals(0.dp, resolved.calculateEndPadding(LayoutDirection.Ltr))
+    }
+
+    @Test
+    fun `bottom inset stacks the host bottom navigation height on top of extra padding`() {
+        val resolved = resolveTabbedScreenAuroraContentPadding(
+            hostContentPadding = PaddingValues(top = 56.dp, bottom = 80.dp),
+            layoutDirection = LayoutDirection.Ltr,
+            extraBottom = 16.dp,
+        )
+
+        assertEquals(96.dp, resolved.calculateBottomPadding())
+        // Top padding from the host is intentionally NOT propagated; the host applies it itself.
+        assertEquals(0.dp, resolved.calculateTopPadding())
+    }
+
+    @Test
+    fun `start and end insets propagate so navigation rail does not overlap content`() {
+        val resolved = resolveTabbedScreenAuroraContentPadding(
+            hostContentPadding = PaddingValues(start = 80.dp, end = 0.dp, bottom = 0.dp),
+            layoutDirection = LayoutDirection.Ltr,
+            extraBottom = 16.dp,
+        )
+
+        assertEquals(80.dp, resolved.calculateStartPadding(LayoutDirection.Ltr))
+        assertEquals(0.dp, resolved.calculateEndPadding(LayoutDirection.Ltr))
+        assertEquals(16.dp, resolved.calculateBottomPadding())
+    }
+
+    @Test
+    fun `start and end insets respect right-to-left layouts`() {
+        val resolved = resolveTabbedScreenAuroraContentPadding(
+            hostContentPadding = PaddingValues(start = 80.dp, end = 12.dp, bottom = 0.dp),
+            layoutDirection = LayoutDirection.Rtl,
+            extraBottom = 16.dp,
+        )
+
+        // Under Rtl, "start" of the source PaddingValues is on the right — but we read it back via
+        // calculateStartPadding(Rtl), which reports the side that is currently the start. The
+        // helper queries with the supplied direction, so the values it captured should round-trip
+        // through Rtl as well.
+        assertEquals(80.dp, resolved.calculateStartPadding(LayoutDirection.Rtl))
+        assertEquals(12.dp, resolved.calculateEndPadding(LayoutDirection.Rtl))
+    }
+
+    @Test
+    fun `extra bottom defaults to 16 dp matching the legacy hard-coded value`() {
+        val resolved = resolveTabbedScreenAuroraContentPadding(
+            hostContentPadding = null,
+            layoutDirection = LayoutDirection.Ltr,
+        )
+
+        assertEquals(16.dp, resolved.calculateBottomPadding())
+    }
+}


### PR DESCRIPTION
## Summary

Reported in chat: on the Home (Aurora) screen, scrolling all the way down to "Recently Added" still leaves the bottom row of cards partially hidden behind the in-app bottom navigation bar — the title and chapter count are not visible even though the list is at its end.

### Root cause

`HomeScreen` uses a `Scaffold` whose `contentPadding` carries the in-app `NavigationBar` height as its bottom inset, but `HomeScreen.kt:251` deliberately applies only the top of that padding so the bottom bar can be rendered translucently over the body (edge-to-edge):

```kotlin
Box(
    modifier = Modifier
        .padding(top = contentPadding.calculateTopPadding())
        .consumeWindowInsets(contentPadding),
)
```

Inside that body, every tab that goes through `TabbedScreenAurora` (Home Hub, Library, History, Browse, Updates, Stats, Categories) ultimately had its content driven by **two hard-coded** call sites in `TabbedScreenAurora.kt`:

```kotlin
tabs[page].content(PaddingValues(bottom = 16.dp), snackbarHostState)
```

The bar height was therefore lost — every tab's `LazyColumn` ended 16 dp from the absolute bottom of the window while the ~80 dp NavigationBar was painted on top, hiding the last item's text. The Home screen's "Recently Added" grid is the most visible offender because its cards include a multi-line title and a chapter count beneath the cover.

### Fix

Pipe the host Scaffold's `PaddingValues` through a new `LocalHostScaffoldContentPadding` `CompositionLocal`:

- `HomeScreen` now wraps the tab body in `CompositionLocalProvider(LocalHostScaffoldContentPadding provides contentPadding)`. The body still applies only the top inset itself, so the existing edge-to-edge rendering of the bottom bar is preserved.
- `TabbedScreenAurora` reads the local and feeds each tab's content through a new pure helper `resolveTabbedScreenAuroraContentPadding(...)`. The helper:
  - falls back to the legacy `bottom = 16.dp` when no host padding is available (preserving behaviour outside `HomeScreen`, e.g. previews/tests);
  - **adds** the host's bottom inset on top of the 16 dp inner buffer so the last `LazyColumn` item clears the bar;
  - propagates `start`/`end` insets so a navigation rail on tablets does not overlap tab content either;
  - never propagates the top inset (the host already applied that).

The change is fully backwards-compatible: every tab body keeps receiving a single `PaddingValues` argument, just with the correct bottom value now.

### Files changed

- `app/src/main/java/eu/kanade/presentation/components/TabbedScreenAurora.kt` — add `LocalHostScaffoldContentPadding`, add `resolveTabbedScreenAuroraContentPadding` helper, replace both hard-coded `PaddingValues(bottom = 16.dp)` call sites with the resolved value.
- `app/src/main/java/eu/kanade/tachiyomi/ui/home/HomeScreen.kt` — wrap the Scaffold's body in `CompositionLocalProvider(LocalHostScaffoldContentPadding provides contentPadding)`.
- `app/src/test/java/eu/kanade/presentation/components/TabbedScreenAuroraContentPaddingTest.kt` — five new unit tests covering: no-host fallback, bottom-only host (the Home case), rail-only host (the tablet case), RTL layouts, and the default-`extraBottom` regression guard that the legacy 16 dp value is preserved.

## Validation

- [x] `./gradlew :app:compileDebugKotlin` — BUILD SUCCESSFUL.
- [x] `./gradlew :app:spotlessCheck` — BUILD SUCCESSFUL.
- [x] `./gradlew :app:testDebugUnitTest --tests "*TabbedScreen*" --tests "*HomeScreen*" --tests "*HomeHub*"` — 80 PASSED, 0 FAILED.
- [x] Self-reviewed the diff: `+188/-60` across 3 files. No public signature changes; `LocalHostScaffoldContentPadding` defaults to `null` so any caller of `TabbedScreenAurora` outside `HomeScreen` keeps the previous 16 dp behaviour.

Requested by: @andarcanum