### PR TITLE
[player] wrap controls Compose tree in TachiyomiTheme

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -81,6 +81,7 @@ import eu.kanade.tachiyomi.ui.player.utils.ChapterUtils.Companion.getStringRes
 import eu.kanade.tachiyomi.util.system.powerManager
 import eu.kanade.tachiyomi.util.system.toShareIntent
 import eu.kanade.tachiyomi.util.system.toast
+import eu.kanade.tachiyomi.util.view.setComposeContent
 import `is`.xyz.mpv.MPVLib
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -271,7 +272,7 @@ class PlayerActivity : BaseActivity() {
             }
             .launchIn(lifecycleScope)
 
-        binding.controls.setContent {
+        binding.controls.setComposeContent {
             val hapticFeedbackMode by uiPreferences.hapticFeedbackMode().collectAsState()
             val eInkProfile by uiPreferences.eInkProfile().collectAsState()
             val anime by viewModel.currentAnime.collectAsState()


### PR DESCRIPTION
## Summary

Reported in chat: in the anime player, every dialog/sheet (episode list, quality picker, audio/subtitle tracks, chapters, playback speed, screenshot sheet, subtitle delay/typography panels, etc.) renders with a light surface and dark text even when the rest of the app is in dark mode. The user's selected accent colour (Aurora/Monet/...) is also lost.

### Root cause

`PlayerActivity` mounts the player UI directly:

```kotlin
binding.controls.setContent {
    ...
    PlayerControls(...)
}
```

(`app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt:274`)

There is **no `TachiyomiTheme { ... }` wrapper**, so every `MaterialTheme.colorScheme.*` reference inside the player's Compose tree resolves to the **default Material 3 light ColorScheme**, regardless of the user's `UiPreferences.appTheme`, `themeDarkAmoled`, or `isSystemInDarkTheme()`.

The overlay controls themselves look fine only because `PlayerControls` forces `LocalContentColor provides Color.White` for its own subtree (controls render on top of the video — text must always be white). But the dialogs/sheets that open from it use `Surface` whose default `containerColor = MaterialTheme.colorScheme.surface` and `Text` with `MaterialTheme.colorScheme.onSurface` — both pick up the wrong (light) values.

For comparison, `ReaderActivity` already does this correctly, via the existing `setComposeContent` helper:

```kotlin
binding.pageNumber.setComposeContent { ... }
binding.dialogRoot.setComposeContent { ... }
```

(`app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt:389,409`)

The helper at `app/src/main/java/eu/kanade/tachiyomi/util/view/ViewExtensions.kt:42-56` wraps content in `TachiyomiTheme { ... }` plus `LocalTextStyle = bodySmall` and `LocalContentColor = onBackground`, and sets `ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed`.

### Fix

Switch `PlayerActivity` from `binding.controls.setContent { ... }` to `binding.controls.setComposeContent { ... }`. This is a single-line change plus an import, and matches what `ReaderActivity` already does.

Effects:

- All `MaterialTheme.colorScheme.*` lookups in the player tree now resolve through `TachiyomiTheme`, which reads `UiPreferences.appTheme` + `themeDarkAmoled` + `isSystemInDarkTheme()` + e-ink prefs. Dark mode → dark dialogs/sheets, the user's accent shows up in primary buttons/highlights.
- The `LocalContentColor provides Color.White` override inside `PlayerControls` is applied below the theme in the tree, so the on-video text overlay still renders white. Verified by inspecting `PlayerControls.kt:169-176`.
- `ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed` is a slightly safer default than the implicit `DisposeOnDetachedFromWindow`.

### Files changed

- `app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt` — `setContent` → `setComposeContent`, add the corresponding import.

## Validation

- [x] `./gradlew :app:compileDebugKotlin` — BUILD SUCCESSFUL.
- [x] `./gradlew :app:spotlessCheck` — BUILD SUCCESSFUL.
- [x] `./gradlew :app:testDebugUnitTest --tests "*Player*"` — 26 PASSED, 0 FAILED.
- [x] Self-reviewed the diff: `+2/-1` in a single file. No public API changes; `setComposeContent` is the same helper `ReaderActivity` already uses.


Requested by: @andarcanum