### PR TITLE
[browse] fix extension search bar disappearing on empty results

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/anime/AnimeExtensionsScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/anime/AnimeExtensionsScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.GetApp
 import androidx.compose.material.icons.outlined.Public
 import androidx.compose.material.icons.outlined.Refresh
+import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.VerifiedUser
 import androidx.compose.material3.Button
@@ -57,7 +58,7 @@ import eu.kanade.tachiyomi.ui.browse.anime.extension.AnimeExtensionUiModel
 import eu.kanade.tachiyomi.ui.browse.anime.extension.AnimeExtensionsScreenModel
 import eu.kanade.tachiyomi.util.system.LocaleHelper
 import eu.kanade.tachiyomi.util.system.launchRequestPackageInstallsPermission
-import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.FastScrollLazyColumn
 import tachiyomi.presentation.core.components.material.PullRefresh
@@ -86,6 +87,7 @@ fun AnimeExtensionScreen(
     onClickUpdateAll: () -> Unit,
     onRefresh: () -> Unit,
     onToggleSection: (AnimeExtensionUiModel.Header.Text) -> Unit,
+    onClearSearch: () -> Unit = {},
 ) {
     val navigator = LocalNavigator.currentOrThrow
 
@@ -105,13 +107,24 @@ fun AnimeExtensionScreen(
                 EmptyScreen(
                     stringRes = msg,
                     modifier = Modifier.padding(contentPadding),
-                    actions = persistentListOf(
-                        EmptyScreenAction(
-                            stringRes = MR.strings.label_extension_repos,
-                            icon = Icons.Outlined.Settings,
-                            onClick = { navigator.push(AnimeExtensionReposScreen()) },
-                        ),
-                    ),
+                    actions = buildList {
+                        if (!searchQuery.isNullOrEmpty()) {
+                            add(
+                                EmptyScreenAction(
+                                    stringRes = MR.strings.action_search,
+                                    icon = Icons.Outlined.Search,
+                                    onClick = onClearSearch,
+                                ),
+                            )
+                        }
+                        add(
+                            EmptyScreenAction(
+                                stringRes = MR.strings.label_extension_repos,
+                                icon = Icons.Outlined.Settings,
+                                onClick = { navigator.push(AnimeExtensionReposScreen()) },
+                            ),
+                        )
+                    }.toPersistentList(),
                 )
             }
             else -> {

--- a/app/src/main/java/eu/kanade/presentation/browse/manga/MangaExtensionsScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/manga/MangaExtensionsScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.GetApp
 import androidx.compose.material.icons.outlined.Public
 import androidx.compose.material.icons.outlined.Refresh
+import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.VerifiedUser
 import androidx.compose.material3.AlertDialog
@@ -58,7 +59,7 @@ import eu.kanade.tachiyomi.ui.browse.manga.extension.MangaExtensionUiModel
 import eu.kanade.tachiyomi.ui.browse.manga.extension.MangaExtensionsScreenModel
 import eu.kanade.tachiyomi.util.system.LocaleHelper
 import eu.kanade.tachiyomi.util.system.launchRequestPackageInstallsPermission
-import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.FastScrollLazyColumn
 import tachiyomi.presentation.core.components.material.PullRefresh
@@ -88,6 +89,7 @@ fun MangaExtensionScreen(
     onClickUpdateAll: () -> Unit,
     onRefresh: () -> Unit,
     onToggleSection: (MangaExtensionUiModel.Header.Text) -> Unit,
+    onClearSearch: () -> Unit = {},
 ) {
     val navigator = LocalNavigator.currentOrThrow
 
@@ -107,13 +109,24 @@ fun MangaExtensionScreen(
                 EmptyScreen(
                     stringRes = msg,
                     modifier = Modifier.padding(contentPadding),
-                    actions = persistentListOf(
-                        EmptyScreenAction(
-                            stringRes = MR.strings.label_extension_repos,
-                            icon = Icons.Outlined.Settings,
-                            onClick = { navigator.push(MangaExtensionReposScreen()) },
-                        ),
-                    ),
+                    actions = buildList {
+                        if (!searchQuery.isNullOrEmpty()) {
+                            add(
+                                EmptyScreenAction(
+                                    stringRes = MR.strings.action_search,
+                                    icon = Icons.Outlined.Search,
+                                    onClick = onClearSearch,
+                                ),
+                            )
+                        }
+                        add(
+                            EmptyScreenAction(
+                                stringRes = MR.strings.label_extension_repos,
+                                icon = Icons.Outlined.Settings,
+                                onClick = { navigator.push(MangaExtensionReposScreen()) },
+                            ),
+                        )
+                    }.toPersistentList(),
                 )
             }
             else -> {

--- a/app/src/main/java/eu/kanade/presentation/browse/novel/NovelExtensionsScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/novel/NovelExtensionsScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.GetApp
 import androidx.compose.material.icons.outlined.Public
 import androidx.compose.material.icons.outlined.Refresh
+import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -42,6 +43,7 @@ import eu.kanade.tachiyomi.extension.InstallStep
 import eu.kanade.tachiyomi.ui.browse.novel.extension.NovelExtensionItem
 import eu.kanade.tachiyomi.ui.browse.novel.extension.NovelExtensionsScreenModel
 import eu.kanade.tachiyomi.util.system.LocaleHelper
+import kotlinx.collections.immutable.toPersistentList
 import tachiyomi.domain.extension.novel.model.NovelPlugin
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.FastScrollLazyColumn
@@ -71,6 +73,7 @@ fun NovelExtensionScreen(
     onUpdateAll: () -> Unit,
     onRefresh: () -> Unit,
     onToggleSection: (String) -> Unit,
+    onClearSearch: () -> Unit = {},
 ) {
     val navigator = LocalNavigator.currentOrThrow
 
@@ -90,13 +93,24 @@ fun NovelExtensionScreen(
                 EmptyScreen(
                     stringRes = msg,
                     modifier = Modifier.padding(contentPadding),
-                    actions = kotlinx.collections.immutable.persistentListOf(
-                        EmptyScreenAction(
-                            stringRes = MR.strings.label_extension_repos,
-                            icon = Icons.Outlined.Public,
-                            onClick = { navigator.push(NovelExtensionReposScreen()) },
-                        ),
-                    ),
+                    actions = buildList {
+                        if (!searchQuery.isNullOrEmpty()) {
+                            add(
+                                EmptyScreenAction(
+                                    stringRes = MR.strings.action_search,
+                                    icon = Icons.Outlined.Search,
+                                    onClick = onClearSearch,
+                                ),
+                            )
+                        }
+                        add(
+                            EmptyScreenAction(
+                                stringRes = MR.strings.label_extension_repos,
+                                icon = Icons.Outlined.Public,
+                                onClick = { navigator.push(NovelExtensionReposScreen()) },
+                            ),
+                        )
+                    }.toPersistentList(),
                 )
             }
             else -> {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -285,6 +286,25 @@ data object BrowseTab : Tab {
             val lastIndex = currentTabs.lastIndex
             if (lastIndex >= 0 && state.currentPage > lastIndex) {
                 state.scrollToPage(lastIndex)
+            }
+        }
+
+        // Close the extension search bar when the user navigates away from the
+        // Extensions sub-tab.  This prevents the search from being "orphaned"
+        // on a tab that doesn't support it, which makes the search icon
+        // invisible and the bar unreachable (see issue #88).
+        val extensionIdx = extensionTabIndex(hideFeedTab)
+        LaunchedEffect(extensionIdx, effectiveSection) {
+            snapshotFlow {
+                state.currentPage to state.isScrollInProgress
+            }.collect { (page, scrolling) ->
+                if (!scrolling && page != extensionIdx) {
+                    when (effectiveSection) {
+                        BrowseSection.Anime -> animeExtensionsScreenModel.search(null)
+                        BrowseSection.Manga -> mangaExtensionsScreenModel.search(null)
+                        BrowseSection.Novel -> novelExtensionsScreenModel.search(null)
+                    }
+                }
             }
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/anime/extension/AnimeExtensionsTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/anime/extension/AnimeExtensionsTab.kt
@@ -92,6 +92,7 @@ fun animeExtensionsTab(
                 onUpdateExtension = extensionsScreenModel::updateExtension,
                 onRefresh = extensionsScreenModel::findAvailableExtensions,
                 onToggleSection = extensionsScreenModel::toggleSection,
+                onClearSearch = { extensionsScreenModel.search("") },
             )
 
             privateExtensionToUninstall?.let { extension ->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/extension/MangaExtensionsTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/extension/MangaExtensionsTab.kt
@@ -88,6 +88,7 @@ fun mangaExtensionsTab(
                 onUpdateExtension = extensionsScreenModel::updateExtension,
                 onRefresh = extensionsScreenModel::findAvailableExtensions,
                 onToggleSection = extensionsScreenModel::toggleSection,
+                onClearSearch = { extensionsScreenModel.search("") },
             )
 
             privateExtensionToUninstall?.let { extension ->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/novel/extension/NovelExtensionsTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/novel/extension/NovelExtensionsTab.kt
@@ -57,6 +57,7 @@ fun novelExtensionsTab(
                 onUpdateAll = extensionsScreenModel::updateAllExtensions,
                 onRefresh = extensionsScreenModel::refresh,
                 onToggleSection = extensionsScreenModel::toggleSection,
+                onClearSearch = { extensionsScreenModel.search("") },
             )
 
             pluginToUninstall?.let { plugin ->


### PR DESCRIPTION
## Summary

Fixes #88 — the extension search bar disappears after searching for an extension that doesn't exist in the current category, and doesn't return until force-stopping the app.

**Root cause:** The extension search is only tied to the Extensions sub-tab via `searchEnabled = true`. When the user has search active and the pager shifts to a non-extension tab (Sources, Feed, or Migrate — e.g. via accidental swipe on the empty results screen), the search becomes "orphaned": the search bar is still logically active but the current tab doesn't support it, so the search icon becomes invisible and the bar is unreachable.

**Fix (two parts):**

1. **Auto-close search on tab switch** (`BrowseTab.kt`): Added a `LaunchedEffect` with `snapshotFlow` that monitors the pager state. When the user navigates away from the Extensions sub-tab and the pager settles, the extension search is automatically closed. This prevents the search from becoming stuck on a non-searchable tab. When the user returns to Extensions, the search icon is clearly visible again.

2. **"Search" action on empty results** (all three extension screens): When the extension search returns no results, the `EmptyScreen` now shows a "Search" action button alongside the existing "Extension repos" button. Tapping it clears the search text and re-opens the search bar, giving users an obvious recovery path.

## Validation

- [x] I ran the required automated checks for this change.
- [x] I self-reviewed the diff and validated critical user flows.

`spotlessCheck` and `compileDebugKotlin` both pass.

Link to Devin session: https://app.devin.ai/sessions/d4dd589995a54983ba0d5df52e783bf4
Requested by: @andarcanum